### PR TITLE
Implement NOMISS flag for getitem.

### DIFF
--- a/repgen/data/value.py
+++ b/repgen/data/value.py
@@ -1075,6 +1075,10 @@ class Value:
 								tmp.time = v[0]
 								haveval = True
 								break
+							elif self.missing == "NOMISS" and v[1] is not None:
+								tmp.value = v[1]
+								tmp.time = v[0]
+
 
 				if haveval == True:
 					return tmp
@@ -1082,6 +1086,9 @@ class Value:
 					if self.missing == "EXACT":
 						return tmp
 					elif self.missing == "MISSOK":
+						return tmp
+					elif self.missing == "NOMISS" and tmp.value is not None:
+						# We found a nearby value
 						return tmp
 			else:
 				raise Exception("date index only valid on a timeseries")

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -33,3 +33,21 @@ def test_gents_generator():
     assert v.values[3][1] == 3
     assert v.values[4][1] == 4
     assert v.values[8][1] == 8
+
+def test_nomiss():
+    """
+    This tests the NOMISS property. When Value.missing is set to NOMISS,
+    attempting to retrieve a value that doesn't exist will cause repgen to return the most recent
+    value found that's earlier than the requested timestamp.
+    """
+    def data():
+        data.index+=1
+        return data.thedata[data.index-1]
+    data.index = 0
+    data.thedata = [0, 1, 2, 3, 4, 5, 6, None, None]
+    t_end = datetime.datetime.now().replace(minute=0,second=0,microsecond=0,tzinfo=TZ("UTC"))
+    t_start = t_end-datetime.timedelta(hours=2)
+    v = Value(dbtype="gents", value = data, tz="PST8PDT", missing="NOMISS", start=t_start,end=t_end, interval=datetime.timedelta(minutes=15), picture="%0.02f")
+    assert len( v.values ) == 9
+    assert v.pop() == "0.00"
+    assert v[t_end].value == 6


### PR DESCRIPTION
This adds implementation for NOMISS to __getitem__, so fetching a value at a timestamp will scan back in time for a file if the exact one isn't found.
This brings it in-line with repgen4 functionality.