### PR TITLE
Fix github releases action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,25 +24,17 @@ jobs:
           VER=`build/repgen -V`
           echo "::set-output name=VERSION::$VER"
           echo "::set-output name=FILENAME::repgen-$VER"
-      - name: tag repo
-        uses: actions/github-script@v7.0.1
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.git.createRef({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
-              ref: `refs/tags/${steps.get_version.outputs.VERSION}`,
-              sha: github.context.sha
-            })
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.1.4
+        uses: softprops/action-gh-release@v2
         env: 
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           tag_name: ${{steps.get_version.outputs.VERSION}}
           release_name: Release ${{steps.get_version.outputs.VERSION}}
+          files: |
+            build/repgen
       - name: Upload File
         id: upload-File
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/${{steps.get_version.outputs.VERSION}}",
-              sha: context.sha
+              owner: github.context.repo.owner,
+              repo: github.context.repo.repo,
+              ref: `refs/tags/${steps.get_version.outputs.VERSION}`,
+              sha: github.context.sha
             })
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Create Release
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+' 
 
 jobs:
   create_release:


### PR DESCRIPTION
This is an attempt to get the error here fixed so that we can auto create releases again. 
https://github.com/USACE-WaterManagement/repgen5/actions/runs/11280353941/job/31373141983


The package creation script for pypi also requires a release be made to run. 